### PR TITLE
[FIX] base_user_role: default user multi-company

### DIFF
--- a/base_user_role/README.rst
+++ b/base_user_role/README.rst
@@ -23,7 +23,7 @@ User roles
     :target: https://runbot.odoo-community.org/runbot/253/12.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module was written to extend the standard functionality regarding users
 and groups management.
@@ -119,6 +119,7 @@ Contributors
 * Sébastien Alix <sebastien.alix@osiell.com>
 * Duc, Dao Dong <duc.dd@komit-consulting.com> (https://komit-consulting.com)
 * Jean-Charles Drubay <jc@komit-consulting.com> (https://komit-consulting.com)
+* Andrius Laukavičius <andrius@focusate.eu> (http://focusate.eu)
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -152,7 +153,7 @@ promote its widespread use.
 
 Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-ABF OSIELL| |maintainer-jcdrubay| 
+|maintainer-ABF OSIELL| |maintainer-jcdrubay|
 
 This module is part of the `OCA/server-backend <https://github.com/OCA/server-backend/tree/12.0/base_user_role>`_ project on GitHub.
 

--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'User roles',
-    'version': '12.0.1.1.0',
+    'version': '12.0.1.1.1',
     'category': 'Tools',
     'author': 'ABF OSIELL, Odoo Community Association (OCA)',
     'license': 'AGPL-3',

--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -19,7 +19,7 @@ class ResUsers(models.Model):
     @api.model
     def _default_role_lines(self):
         default_user = self.env.ref(
-            'base.default_user', raise_if_not_found=False)
+            'base.default_user', raise_if_not_found=False).sudo()
         default_values = []
         if default_user:
             for role_line in default_user.role_line_ids:


### PR DESCRIPTION
When creating user, default roles are using `base.default_user`, which
in multi-company case, can be from different company than user is being
created for. If thats the case, user creating another user, will get
access error, when trying to read default template user.

To work around that, we use sudo, to make sure, template user data can
be read regardless of a company.

Also improved the way base_user_role tests are run. Changed base test
class from TransactionCase to SavepointCase.

From how tests are ran perspective, both classes behave the same: each
test uses set up which is roll backed after.

But the difference is that SavepointCase case is much faster, because
it calls setUpClass once and saves this case for all tests (reusing
saved state).